### PR TITLE
Fix some typos in tests text

### DIFF
--- a/test/lib/processors/raml.js
+++ b/test/lib/processors/raml.js
@@ -28,7 +28,7 @@ describe('raml', function () {
         var results = postprocess([], fileName)
 
         assert.isArray(results, 'should return an array')
-        assert.lengthOf(results, 0, 'valid.raml shouldnt have any errors')
+        assert.lengthOf(results, 0, 'valid.raml should not have any errors')
       })
 
       it('should return an error for the missing include', function () {
@@ -40,10 +40,10 @@ describe('raml', function () {
         assert.lengthOf(results, 2, 'should return 2 errors')
         assert.strictEqual(results[0].ruleId, 'bad-raml')
         assert.strictEqual(results[0].line, 12, 'should point to 12 line')
-        assert.strictEqual(results[0].column, 13, 'should point to 22 character')
+        assert.strictEqual(results[0].column, 13, 'should point to 13 character')
         assert.strictEqual(results[1].ruleId, 'bad-raml')
         assert.strictEqual(results[1].line, 12, 'should point to 12 line')
-        assert.strictEqual(results[1].column, 13, 'should point to 22 character')
+        assert.strictEqual(results[1].column, 13, 'should point to 13 character')
       })
 
       it('should return an error for the authorizationUri Twice', function () {
@@ -89,7 +89,7 @@ describe('raml', function () {
         assert.strictEqual(results[1].line, 12, 'should point to 12 line')
       })
 
-      it('should return an errors for not valid example', function () {
+      it('should return an error for not valid example', function () {
         var fileName = makeRAMLFilePath('notValidExample.raml')
         var text = fs.readFileSync(fileName)
         preprocess(text, fileName)


### PR DESCRIPTION
Fixed some typos.

Also for the missingInclude.raml test, the text refers to incorrect character position.